### PR TITLE
fixed the loading issue for Turkish clients

### DIFF
--- a/src/main/java/com/lothrazar/storagenetwork/block/cable/BlockCable.java
+++ b/src/main/java/com/lothrazar/storagenetwork/block/cable/BlockCable.java
@@ -55,7 +55,7 @@ public class BlockCable extends Block {
 
     @Override
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ENGLISH);
     }
   }
 


### PR DESCRIPTION
In Turkish language upper case of "i" is "İ", lower case of "I" is "ı". While loading; Enum EnumConnectType.INVENTORY change as "ınventory" by `toLowerCase()`, It should be "inventory".