### PR TITLE
Search bar: Fit tooltip, fix clicking on ends and nudge clear button

### DIFF
--- a/src/main/java/com/lothrazar/storagenetwork/gui/NetworkWidget.java
+++ b/src/main/java/com/lothrazar/storagenetwork/gui/NetworkWidget.java
@@ -174,10 +174,11 @@ public class NetworkWidget {
   }
 
   public boolean inSearchBar(double mouseX, double mouseY) {
-    return gui.isInRegion(searchBar.x - gui.getGuiLeft() + 14,
-        searchBar.y - gui.getGuiTop(),
-        searchBar.getWidth(), 9 + 6,
-        mouseX, mouseY);
+    return gui.isInRegion(
+      searchBar.x - gui.getGuiLeft(), searchBar.y - gui.getGuiTop(), // x, y
+      searchBar.getWidth(), searchBar.getHeight(), // width, height
+      mouseX, mouseY
+    );
   }
 
   public void initSearchbar() {
@@ -264,12 +265,6 @@ public class NetworkWidget {
         return;
       }
     }
-    if (searchBar.mouseClicked(mouseX, mouseY, mouseButton)) {
-      if (mouseButton == UtilTileEntity.MOUSE_BTN_RIGHT) {
-        clearSearch();
-        return;
-      }
-    }
     ItemStack stackCarriedByMouse = StorageNetwork.proxy.getClientPlayer().inventory.getItemStack();
     if (!stackUnderMouse.isEmpty()
         && (mouseButton == UtilTileEntity.MOUSE_BTN_LEFT || mouseButton == UtilTileEntity.MOUSE_BTN_RIGHT)
@@ -309,7 +304,7 @@ public class NetworkWidget {
       JeiSettings.setJeiSearchSync(!JeiSettings.isJeiSearchSynced());
     });
     jeiBtn.setHeight(16);
-    clearTextBtn = new GuiButtonRequest(gui.getGuiLeft() + 64, y, "X", (p) -> {
+    clearTextBtn = new GuiButtonRequest(gui.getGuiLeft() + 63, y, "X", (p) -> {
       this.clearSearch();
     });
     clearTextBtn.setHeight(16);


### PR DESCRIPTION
After playing the mod recently, I noticed the tooltip region didn't really match the search bar, so I just resized that to fit better. Managed to get rid of a few magic numbers in the process, too.

During which, I also noticed that the search bar didn't focus if you clicked on the ends of it. That was happening because the check `if(searchBar.mouseClicked(mouseX, mouseY, mouseButton))` was setting `isFocused` to false on the `searchBar`, for whatever reason, when it was called. I've removed that entire check because, unless I've missed something, it was doing the same thing as `if (inSearchBar(mouseX, mouseY))` but also unfocusing the bar. Clearing with RMB still works perfectly.

I nudged the clear search bar button to the left by one pixel because it looks cleaner IMO, but it can be left alone if you want.