### PR TITLE
Fix remote not working within 30 blocks of master

### DIFF
--- a/src/main/java/mrriegel/storagenetwork/gui/GuiHandler.java
+++ b/src/main/java/mrriegel/storagenetwork/gui/GuiHandler.java
@@ -44,7 +44,9 @@ public class GuiHandler implements IGuiHandler {
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     BlockPos pos = new BlockPos(x, y, z);
-    UtilTileEntity.updateTile(world, pos);
+    if (ID != GuiIDs.REMOTE.ordinal()) {
+      UtilTileEntity.updateTile(world, pos);
+    }
     if (ID == GuiIDs.LINK.ordinal()) {
       return new ContainerCableLink((TileCable) world.getTileEntity(pos), player.inventory);
     }


### PR DESCRIPTION
I hit a similar issue as [this Reddit post](https://www.reddit.com/r/SkyFactory/comments/bkii6f/a_little_trouble_with_simple_storage_remotes/). Essentially, if you were within 30 blocks of the master, your remote wouldn't work, and under certain situations, removing blocks nearby solved the issue. This is because the remote uses the x-coordinate to signal which hand the GUI is triggered from, and so when the updater goes to update that block, it's looking at a block in the world that doesn't relate to the mod at all. If it happens to or is air, this code works fine. If it is a chest or furnace (or possibly other blocks), it will throw an exception. This pull request stops the block update from occurring if the GUI being launched is the remote.