### PR TITLE
Added config option for disabling the auto focus of the search bar

### DIFF
--- a/src/main/java/com/lothrazar/storagenetwork/gui/NetworkWidget.java
+++ b/src/main/java/com/lothrazar/storagenetwork/gui/NetworkWidget.java
@@ -184,7 +184,7 @@ public class NetworkWidget {
     searchBar.setEnableBackgroundDrawing(false);
     searchBar.setVisible(true);
     searchBar.setTextColor(16777215);
-    searchBar.setFocused2(true);
+    searchBar.setFocused2(StorageNetwork.config.enableAutoSearchFocus());
     if (JeiSettings.isJeiLoaded() && JeiSettings.isJeiSearchSynced()) {
       searchBar.setText(JeiHooks.getFilterText());
     }

--- a/src/main/java/com/lothrazar/storagenetwork/registry/ConfigRegistry.java
+++ b/src/main/java/com/lothrazar/storagenetwork/registry/ConfigRegistry.java
@@ -20,6 +20,7 @@ public class ConfigRegistry {
   public static IntValue EXCHANGEBUFFER;
   private static BooleanValue RELOADONCHUNK;
   private static ConfigValue<List<String>> IGNORELIST;
+  private static BooleanValue ENABLEAUTOSEARCHFOCUS;
   //    allowFastWorkBenchIntegration = config.getBoolean("allowFastWorkBenchIntegration", category, true, "Allow 'fastworkbench' project to integrate into storage network crafting grids.  Turning off lets you disable integration without uninstalling mod.  Client and server should match for best outcome.");
   static {
     initConfig();
@@ -38,6 +39,8 @@ public class ConfigRegistry {
         list);
     EXCHANGEBUFFER = COMMON_BUILDER.comment("How many itemstacks from the network are visible to external connections through the storagenetwork:exchange.  Too low and not all items can pass through, too large and there will be packet/buffer overflows.")
         .defineInRange("exchangeBufferSize", 1024 * 1024 * 1024 * 1024, 1, Integer.MAX_VALUE / 16);
+    ENABLEAUTOSEARCHFOCUS = COMMON_BUILDER.comment("Set to false to disable the automatic focus of the searchbar")
+            .define("enableAutoSearchFocus", true);
     COMMON_BUILDER.pop();
     COMMON_CONFIG = COMMON_BUILDER.build();
   }
@@ -66,5 +69,9 @@ public class ConfigRegistry {
 
   public List<String> ignorelist() {
     return IGNORELIST.get();
+  }
+
+  public boolean enableAutoSearchFocus() {
+    return ENABLEAUTOSEARCHFOCUS.get();
   }
 }


### PR DESCRIPTION
Adds an option to enable/disable the auto focus of the search bar on the corresponding GUIs, set to **true** by default in order to keep the same behavior the search bar currently has.

This closes [#263](https://github.com/Lothrazar/Storage-Network/issues/263)