### PR TITLE
Mark cables as non-transparent for pathfinder

### DIFF
--- a/src/main/java/com/lothrazar/storagenetwork/block/cable/BlockCable.java
+++ b/src/main/java/com/lothrazar/storagenetwork/block/cable/BlockCable.java
@@ -14,6 +14,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.inventory.InventoryHelper;
 import net.minecraft.item.ItemStack;
+import net.minecraft.pathfinding.PathType;
 import net.minecraft.state.EnumProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.tileentity.TileEntity;
@@ -142,6 +143,12 @@ public class BlockCable extends BaseBlock {
   @Override
   public boolean hasTileEntity(BlockState state) {
     return true;
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public boolean allowsMovement(BlockState state, IBlockReader world, BlockPos pos, PathType type) {
+    return false;
   }
 
   @Override


### PR DESCRIPTION
It's me again. :slightly_smiling_face: 

This fix allows mobs to jump over storage cables instead of simply getting stuck in them.

This is basically the same issue as https://github.com/refinedmods/refinedstorage/issues/2911.