### PR TITLE
Improved performance for export nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ crash-reports/
 *.lnk
 *.jks
 secret.properties
+.vscode

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=false
 # as needed run/server.properties : online-mode=false
 # implementation fg.deobf("curse.maven:simple-storage-network-268495:3163007")
 curse_id=268495
-mod_version=1.6.2
+mod_version=1.7.0
 
 mc_version=1.18.2
 forge_version=40.1.54

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/lothrazar/storagenetwork/api/IConnectableLink.java
+++ b/src/main/java/com/lothrazar/storagenetwork/api/IConnectableLink.java
@@ -1,6 +1,9 @@
 package com.lothrazar.storagenetwork.api;
 
 import java.util.List;
+
+import com.lothrazar.storagenetwork.util.StackProviderBatch;
+
 import net.minecraft.world.item.ItemStack;
 
 /**
@@ -80,4 +83,8 @@ public interface IConnectableLink {
   void setPriority(int value);
 
   void setFilter(int value, ItemStack copy);
+
+  public ItemStack extractFromSlot(int slot, int amount, boolean simulate);
+
+  void addToStackProviderBatch(StackProviderBatch availableItems);
 }

--- a/src/main/java/com/lothrazar/storagenetwork/api/IItemStackMatcher.java
+++ b/src/main/java/com/lothrazar/storagenetwork/api/IItemStackMatcher.java
@@ -23,4 +23,6 @@ public interface IItemStackMatcher {
    * @return
    */
   boolean match(ItemStack stack);
+
+  boolean match(IItemStackMatcher matcher);
 }

--- a/src/main/java/com/lothrazar/storagenetwork/block/main/TileMain.java
+++ b/src/main/java/com/lothrazar/storagenetwork/block/main/TileMain.java
@@ -72,6 +72,7 @@ public class TileMain extends BlockEntity {
   }
 
   public void executeRequestBatch(RequestBatch batch) {
+    batch.sort();
     nw.executeRequestBatch(batch);
   }
 

--- a/src/main/java/com/lothrazar/storagenetwork/block/main/TileMain.java
+++ b/src/main/java/com/lothrazar/storagenetwork/block/main/TileMain.java
@@ -1,6 +1,7 @@
 package com.lothrazar.storagenetwork.block.main;
 
 import java.util.Set;
+
 import com.lothrazar.storagenetwork.StorageNetworkMod;
 import com.lothrazar.storagenetwork.api.DimPos;
 import com.lothrazar.storagenetwork.api.EnumStorageDirection;
@@ -10,6 +11,8 @@ import com.lothrazar.storagenetwork.api.IItemStackMatcher;
 import com.lothrazar.storagenetwork.capability.handler.ItemStackMatcher;
 import com.lothrazar.storagenetwork.registry.SsnRegistry;
 import com.lothrazar.storagenetwork.registry.StorageNetworkCapabilities;
+import com.lothrazar.storagenetwork.util.Request;
+import com.lothrazar.storagenetwork.util.RequestBatch;
 import com.lothrazar.storagenetwork.util.UtilInventory;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -66,6 +69,10 @@ public class TileMain extends BlockEntity {
     ItemStack result = nw.request(matcher, size, simulate);
     //if not found then ?
     return result;
+  }
+
+  public void executeRequestBatch(RequestBatch batch) {
+    nw.executeRequestBatch(batch);
   }
 
   private DimPos getDimPos() {
@@ -178,12 +185,15 @@ public class TileMain extends BlockEntity {
    */
   private void updateExports() {
     Set<IConnectable> conSet = nw.getConnectables();
+    RequestBatch requestBatch = new RequestBatch();
+
     for (IConnectable connectable : conSet) {
       if (connectable == null || connectable.getPos() == null) {
-        //        StorageNetwork.log("null connectable or pos : updateExports() ");
+        // StorageNetwork.log("null connectable or pos : updateExports() ");
         continue;
       }
-      IConnectableItemAutoIO storage = connectable.getPos().getCapability(StorageNetworkCapabilities.CONNECTABLE_AUTO_IO, null);
+      IConnectableItemAutoIO storage = connectable.getPos()
+          .getCapability(StorageNetworkCapabilities.CONNECTABLE_AUTO_IO, null);
       if (storage == null) {
         continue;
       }
@@ -199,7 +209,7 @@ public class TileMain extends BlockEntity {
       if (storage.needsRedstone()) {
         boolean power = level.hasNeighborSignal(connectable.getPos().getBlockPos());
         if (power == false) {
-          //  StorageNetwork.log(power + " Export pow here ; needs yes skip me");
+          // StorageNetwork.log(power + " Export pow here ; needs yes skip me");
           continue;
         }
       }
@@ -207,58 +217,41 @@ public class TileMain extends BlockEntity {
         if (matcher.getStack().isEmpty()) {
           continue;
         }
-        //default amt to request. can be overriden by other upgrades
-        int amtToRequest = storage.getTransferRate();
-        //check operations upgrade for export 
+
+        Request request = new Request(storage);
+        // default amt to request. can be overriden by other upgrades
+        // check operations upgrade for export
         boolean stockMode = storage.isStockMode();
         if (stockMode) {
           StorageNetworkMod.log("stockMode == TRUE ; updateExports: attempt " + matcher.getStack());
-          //STOCK upgrade means
+          // STOCK upgrade means
           try {
-            BlockEntity tileEntity = level.getBlockEntity(connectable.getPos().getBlockPos().relative(storage.facingInventory()));
-            IItemHandler targetInventory = tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).orElse(null);
-            //request with false to see how many even exist in there.
-            int stillNeeds = UtilInventory.containsAtLeastHowManyNeeded(targetInventory, matcher.getStack(), matcher.getStack().getCount());
+            BlockEntity tileEntity = level
+                .getBlockEntity(connectable.getPos().getBlockPos().relative(storage.facingInventory()));
+            IItemHandler targetInventory = tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
+                .orElse(null);
+            // request with false to see how many even exist in there.
+            int stillNeeds = UtilInventory.containsAtLeastHowManyNeeded(targetInventory, matcher.getStack(),
+                matcher.getStack().getCount());
             if (stillNeeds == 0) {
-              //they dont need any more, they have the stock they need
+              // they dont need any more, they have the stock they need
               StorageNetworkMod.log("stockMode continnue; canc");
               continue;
             }
-            amtToRequest = Math.min(stillNeeds, amtToRequest);
-            StorageNetworkMod.log("updateExports stock mode edited value: amtToRequest = " + amtToRequest);
-          }
-          catch (Throwable e) {
+            request.setCount(Math.min(stillNeeds, request.getCount()));
+            StorageNetworkMod.log("updateExports stock mode edited value: amtToRequest = " + request.getCount());
+          } catch (Throwable e) {
             StorageNetworkMod.LOGGER.error("Error thrown from a connected block" + e);
           }
         }
-        if (matcher.getStack().isEmpty() || amtToRequest == 0) {
-          //either the thing is empty or we are requesting none
+        if (matcher.getStack().isEmpty() || request.getCount() == 0) {
+          // either the thing is empty or we are requesting none
           continue;
         }
-        ItemStack requestedStack = this.request((ItemStackMatcher) matcher, amtToRequest, true);
-        if (requestedStack.isEmpty()) {
-          continue;
-        }
-        //     StorageNetwork.log("updateExports: found requestedStack = " + requestedStack);
-        // The stack is available in the network, let's simulate inserting it into the storage
-        ItemStack insertedSim = storage.insertStack(requestedStack, true);
-        // Determine the amount of items moved in the stack
-        if (!insertedSim.isEmpty()) {
-          int movedItems = requestedStack.getCount() - insertedSim.getCount();
-          if (movedItems <= 0) {
-            continue;
-          }
-          requestedStack.setCount(movedItems);
-        }
-        // Alright, some items got moved in the simulation. Let's do it for real this time.
-        ItemStack realExtractedStack = request(new ItemStackMatcher(requestedStack, false, true), requestedStack.getCount(), false);
-        if (realExtractedStack.isEmpty()) {
-          continue;
-        }
-        storage.insertStack(realExtractedStack, false);
-        break;
+        requestBatch.put(matcher.getStack().getItem(), request);
       }
     }
+    executeRequestBatch(requestBatch);
   }
 
   public static void clientTick(Level level, BlockPos blockPos, BlockState blockState, TileMain tile) {}

--- a/src/main/java/com/lothrazar/storagenetwork/capability/CapabilityConnectableAutoIO.java
+++ b/src/main/java/com/lothrazar/storagenetwork/capability/CapabilityConnectableAutoIO.java
@@ -364,4 +364,9 @@ public class CapabilityConnectableAutoIO implements INBTSerializable<CompoundTag
   public UpgradesItemStackHandler getUpgrades() {
     return upgrades;
   }
+
+  public void extractFromSlot(int slot){
+    
+  }
+
 }

--- a/src/main/java/com/lothrazar/storagenetwork/capability/handler/ItemStackMatcher.java
+++ b/src/main/java/com/lothrazar/storagenetwork/capability/handler/ItemStackMatcher.java
@@ -20,7 +20,8 @@ public class ItemStackMatcher implements IItemStackMatcher {
     this.nbt = nbt;
   }
 
-  private ItemStackMatcher() {}
+  private ItemStackMatcher() {
+  }
 
   public void readFromNBT(CompoundTag compound) {
     CompoundTag c = (CompoundTag) compound.get("stack");
@@ -83,5 +84,10 @@ public class ItemStackMatcher implements IItemStackMatcher {
       return false;
     }
     return stackIn.getItem() == stack.getItem();
+  }
+
+  public boolean match(IItemStackMatcher matcher) {
+    ItemStack stack = matcher.getStack();
+    return match(stack);
   }
 }

--- a/src/main/java/com/lothrazar/storagenetwork/util/Batch.java
+++ b/src/main/java/com/lothrazar/storagenetwork/util/Batch.java
@@ -1,0 +1,20 @@
+package com.lothrazar.storagenetwork.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import net.minecraft.world.item.Item;
+
+public class Batch<K> extends HashMap<Item, List<K>> {
+    public List<K> put(Item item, K object) {
+        if (containsKey(item)) {
+            List<K> matchingList = super.get(item);
+            matchingList.add(object);
+            return matchingList;
+        }
+        List<K> newList = new ArrayList<K>();
+        newList.add(object);
+        return super.put(item, newList);
+    }
+}

--- a/src/main/java/com/lothrazar/storagenetwork/util/Request.java
+++ b/src/main/java/com/lothrazar/storagenetwork/util/Request.java
@@ -22,6 +22,10 @@ public class Request {
         return count;
     }
 
+    public int getPriority() {
+        return storage.getPriority();
+    }
+
     public Boolean insertStack(IConnectableLink providerStorage, int slot) {
         ItemStack simulatedExtractedStack = providerStorage.extractFromSlot(slot, getCount(), true);
 

--- a/src/main/java/com/lothrazar/storagenetwork/util/Request.java
+++ b/src/main/java/com/lothrazar/storagenetwork/util/Request.java
@@ -1,0 +1,53 @@
+package com.lothrazar.storagenetwork.util;
+
+import com.lothrazar.storagenetwork.api.IConnectableItemAutoIO;
+import com.lothrazar.storagenetwork.api.IConnectableLink;
+
+import net.minecraft.world.item.ItemStack;
+
+public class Request {
+    private Integer count = 0;
+    private IConnectableItemAutoIO storage;
+
+    public Request(IConnectableItemAutoIO storage) {
+        this.count = storage.getTransferRate();
+        this.storage = storage;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public Boolean insertStack(IConnectableLink providerStorage, int slot) {
+        ItemStack simulatedExtractedStack = providerStorage.extractFromSlot(slot, getCount(), true);
+
+        if (simulatedExtractedStack.isEmpty()) {
+            return false;
+        }
+
+        int movedItems = 0;
+        ItemStack simulatedInsertedStack = storage.insertStack(simulatedExtractedStack, true);
+        if (simulatedInsertedStack.isEmpty()) {
+            movedItems = getCount();
+            setCount(0);
+        } else {
+            movedItems = simulatedExtractedStack.getCount() - simulatedInsertedStack.getCount();
+            setCount(movedItems);
+        }
+
+        // real extraction
+
+        ItemStack realExtractedStack = providerStorage.extractFromSlot(slot, movedItems, false);
+        storage.insertStack(realExtractedStack, false);
+
+        // Determine the amount of items moved in the stack
+        if (getCount() == 0) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/lothrazar/storagenetwork/util/RequestBatch.java
+++ b/src/main/java/com/lothrazar/storagenetwork/util/RequestBatch.java
@@ -1,6 +1,7 @@
 package com.lothrazar.storagenetwork.util;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import com.lothrazar.storagenetwork.api.IConnectableLink;
@@ -22,5 +23,41 @@ public class RequestBatch extends Batch<Request> {
             }
         }
         put(item, remainingRequests);
+    }
+
+    public void sort() {
+        Collection<List<Request>> requests = this.values();
+        for(List<Request> requestList : requests) {
+            quickSort(requestList, 0, requestList.size() - 1);
+        }
+    }
+
+    private void quickSort(List<Request> requestList, int start, int end) {
+        if (start < end) {
+            int partitionInd = partition(requestList, start, end);
+            quickSort(requestList, start, partitionInd - 1);
+            quickSort(requestList, partitionInd + 1, end);
+        }
+    }
+
+    private int partition(List<Request> requestList, int start, int end) {
+        int pivot = requestList.get(end).getPriority();
+        int i = (start - 1);
+        for (int j = start; j < end; j++) {
+            if (requestList.get(j).getPriority() <= pivot) {
+                i++;
+
+                Request highTemp = requestList.get(i);
+                Request lowTemp = requestList.get(j);
+                requestList.set(i, lowTemp);
+                requestList.set(j, highTemp);
+            }
+        }
+        Request swapTemp = requestList.get(i + 1);
+        Request temp = requestList.get(end);
+        requestList.set(i + 1, temp);
+        requestList.set(end, swapTemp);
+
+        return i + 1;
     }
 }

--- a/src/main/java/com/lothrazar/storagenetwork/util/RequestBatch.java
+++ b/src/main/java/com/lothrazar/storagenetwork/util/RequestBatch.java
@@ -1,0 +1,26 @@
+package com.lothrazar.storagenetwork.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lothrazar.storagenetwork.api.IConnectableLink;
+
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+public class RequestBatch extends Batch<Request> {
+    public void extractStacks(IConnectableLink providerStorage, Integer slot, Item item) {
+        List<Request> requests = get(item);
+        List<Request> remainingRequests = new ArrayList<Request>();
+        for (Request request : requests) {
+            if (!request.insertStack(providerStorage, slot)) {
+                remainingRequests.add(request);
+            }
+            ItemStack stack = providerStorage.extractFromSlot(slot, 1, true);
+            if (stack.isEmpty()) {
+                return;
+            }
+        }
+        put(item, remainingRequests);
+    }
+}

--- a/src/main/java/com/lothrazar/storagenetwork/util/StackProvider.java
+++ b/src/main/java/com/lothrazar/storagenetwork/util/StackProvider.java
@@ -1,0 +1,21 @@
+package com.lothrazar.storagenetwork.util;
+
+import com.lothrazar.storagenetwork.api.IConnectableLink;
+
+public class StackProvider {
+    IConnectableLink storage;
+    int slot;
+
+    public StackProvider(IConnectableLink storage, int slot) {
+        this.storage = storage;
+        this.slot = slot;
+    }
+
+    public IConnectableLink getStorage() {
+        return storage;
+    }
+
+    public int getSlot() {
+        return slot;
+    }
+}

--- a/src/main/java/com/lothrazar/storagenetwork/util/StackProviderBatch.java
+++ b/src/main/java/com/lothrazar/storagenetwork/util/StackProviderBatch.java
@@ -1,0 +1,4 @@
+package com.lothrazar.storagenetwork.util;
+
+public class StackProviderBatch extends Batch<StackProvider> {
+}


### PR DESCRIPTION
We noticed that the network is not scaling well. When you are connecting a lot of chests and have many export nodes with a bunch of filters in them the server starts to lag. That happens because we are searching every chest for every defined filter item in every export node.

The fix is to go through all the connected chests an grouping the items in them. Then we are also grouping all the requested items in the export nodes by their requested item. With these two groups we are able to search for the needed items without iterating every chest over and over again.

What we also did is grouping the requested items by their priority. That means, that lowering the priority on an export node makes it  receive items before the other export nodes with a higher priority.