### PR TITLE
Fixed export on chained furnances

### DIFF
--- a/src/main/java/com/lothrazar/storagenetwork/block/main/TileMain.java
+++ b/src/main/java/com/lothrazar/storagenetwork/block/main/TileMain.java
@@ -143,10 +143,10 @@ public class TileMain extends BlockEntity {
         }
         if (ioCap.ioDirection() == EnumStorageDirection.OUT) {
           requestBatch = ioCap.runExport(this);
+          executeRequestBatch(requestBatch);
         }
       }
     }
-    executeRequestBatch(requestBatch);
   }
 
   private void refresh() {


### PR DESCRIPTION
Chained furnances and other storages that use export cables would immediately place all required items in only a single storage.
This seems to solve it. (may cause slight perf issues though, not thoroughly tested.)